### PR TITLE
Minor bug fixes with setup, added error handling

### DIFF
--- a/sfindercompanion.bat
+++ b/sfindercompanion.bat
@@ -1,8 +1,41 @@
+::[Bat To Exe Converter]
+::
+::YAwzoRdxOk+EWAnk
+::fBw5plQjdG8=
+::YAwzuBVtJxjWCl3EqQJgSA==
+::ZR4luwNxJguZRRnk
+::Yhs/ulQjdF+5
+::cxAkpRVqdFKZSDk=
+::cBs/ulQjdF+5
+::ZR41oxFsdFKZSDk=
+::eBoioBt6dFKZSDk=
+::cRo6pxp7LAbNWATEpCI=
+::egkzugNsPRvcWATEpCI=
+::dAsiuh18IRvcCxnZtBJQ
+::cRYluBh/LU+EWAnk
+::YxY4rhs+aU+JeA==
+::cxY6rQJ7JhzQF1fEqQJQ
+::ZQ05rAF9IBncCkqN+0xwdVs0
+::ZQ05rAF9IAHYFVzEqQJQ
+::eg0/rx1wNQPfEVWB+kM9LVsJDGQ=
+::fBEirQZwNQPfEVWB+kM9LVsJDGQ=
+::cRolqwZ3JBvQF1fEqQJQ
+::dhA7uBVwLU+EWDk=
+::YQ03rBFzNR3SWATElA==
+::dhAmsQZ3MwfNWATElA==
+::ZQ0/vhVqMQ3MEVWAtB9wSA==
+::Zg8zqx1/OA3MEVWAtB9wSA==
+::dhA7pRFwIByZRRnk
+::Zh4grVQjdCyDJGyX8VAjFDRDSQqRAE+/Fb4I5/jH2++TsEQOaPE5cYHf36ayM+Ya5EHhZ5Ui22pblsIDAlVdZhfL
+::YB416Ek+ZG8=
+::
+::
+::978f952a14a936cc963da21a135fa983
 @echo off
 setlocal enableextensions
 
 : 'start'
-if exist sfinder.jar set "start=java -jar sfinder.jar"
+if exist sfinder.jar (set "start=java -jar sfinder.jar") else (echo This file isn't in the right directory! Make sure that this file is in the same directory as the file "sfinder.jar" from Knewjade's solution finder. If you don't have it installed, please do so here: https://github.com/knewjade/solution-finder/releases. && pause && exit)
 set /p mode=What mode do you want to use? [Type "spin", "percent", "path", or "setup".] 
 if [%mode%] == [] echo You didn't input anything. Please try again. && goto 'start'
 if /I %mode%==spin goto 'fumen'
@@ -45,7 +78,7 @@ set /p fillBottom=How high is your T-spin off the ground? (Will default to 0).
 if [%fillBottom%] == [] set fillBottom=0
 set /p maxRoof=How high should we put pieces in order to find your T-Spin? (Defaults to being done automatically.) 
 if [%maxRoof%] == [] set maxRoof=-1
-set /p etc=Any other specifications you need? (Check https://knewjade.github.io/sfinder-docs/contents/spin/main.html for a full list!)
+set /p etc=Any other specifications you need? (Check https://knewjade.github.io/sfinder-docs/contents/spin/main.html for a full list!) 
 goto 'exportSpin'
 
 : 'exportSpin'
@@ -80,7 +113,7 @@ if [%drop%] == [] set drop=softdrop
 set /p logPath=Where should the results of this be saved? (All outputs are saved in the output folder, default is therefore "percent.txt") 
 if [%logPath%] == [] set logPath=percent.txt
 set logPath=output/%logPath%
-set /p etc=Any other specifications you need? (Check https://knewjade.github.io/sfinder-docs/contents/percent/main.html for a full list!)
+set /p etc=Any other specifications you need? (Check https://knewjade.github.io/sfinder-docs/contents/percent/main.html for a full list!) 
 goto 'exportPercent'
 
 : 'exportPercent'
@@ -101,7 +134,7 @@ pause
 exit
 
 : 'path'
-set /p patterns=What bag do you want? (Will default to *p7, check https://knewjade.github.io/sfinder-docs/contents/patterns.html if confused on how to allocate bags). 
+set /p patterns=What bag do you want? (Will default to *p7, check https://knewjade.github.io/sfinder-docs/contents/patterns.html if confused on how to allocate bags).  
 if [%patterns%] == [] set patterns=*p7
 set /p hold=Should hold be used? [Answer "yes" or "no"] (Will default to yes). 
 if [%hold%] == [] set hold=use
@@ -135,19 +168,20 @@ pause
 exit
 
 : 'setup'
-set /p patterns=What bag do you want? (Will default to *p7, check https://knewjade.github.io/sfinder-docs/contents/patterns.html if confused on how to allocate bags). 
+set /p patterns=What bag do you want? (Will default to *p7, check https://knewjade.github.io/sfinder-docs/contents/patterns.html if confused on how to allocate bags).  
 if [%patterns%] == [] set patterns=*p7
 set /p holes=Should we allow setups with holes in the margin space (if it exists) to be counted? [Answer "none" for all holes to be excluded, even if there is a gap where a piece could be inserted, answer "some" for all holes to be excluded, except ones with gaps where pieces could be inserted, or "all" for all holes to be allowed.] (Will default to all) 
-if [%holes%] == [] set holes=none
+if [%holes%] == [] set holes=n0ne
 if /I %holes%==none set holes=holes
 if /I %holes%==some set holes=strict-holes
 if /I %holes%==all set holes=none
+if /I %holes%==n0ne set holes=none
 set /p fill=What mino in the field indicates spaces that should be filled by the setup? (Will default to I) 
 if [%fill%] == [] set fill=I
 set /p margin=What mino in the field indicates spaces that may or may not be filled, but if filled, should not include holes? (Will default to O) 
 if [%margin%] == [] set margin=O
 set /p free=What mino in the field indicates spaces that may or may not be filled, and can include spaces in them? (Will default to S) 
-if defined %free% echo null>nul else set free=S
+if [%free%] == [] set free=S
 set /p drop=What types of drops and rotations should be allowed? [Answer "softdrop" for all types, answer "harddrop" for only harddrops, answer "180" for all types and 180s, answer "t-softdrop" to only softdrop the T mino but hard drop everything else.] (Will default to softdrop) 
 if [%drop%] == [] set drop=softdrop
 set /p hold=Should hold be used? [Answer "yes" or "no"] (Will default to yes). 


### PR DESCRIPTION
Fixed the following:

- A bug that caused the setup command to not correctly set a default when asking for the free block to specify (should've defaulted to S, instead defaulted to nothing at all)
- A bug that caused the setup command to always default to not allowing any holes (should've defaulted to allowing all)

Added the following: 

- An error handler that detects the presence of the sfinder.jar file from Knewjade's Solution Finder before running the program proper.